### PR TITLE
Quote application name and adjust `xattr checkCmd` properly

### DIFF
--- a/Sentinel/Dashboard.swift
+++ b/Sentinel/Dashboard.swift
@@ -211,7 +211,7 @@ struct DropQuarantine: DropDelegate {
                 }
                 Task
                 {
-                    _ = await CmdRunDrop(cmd: "xattr -rd com.apple.quarantine \(url.path)", type: "quarantine", appState: appState)
+                    _ = await CmdRunDrop(cmd: "xattr -rd com.apple.quarantine '\(url.path)'", type: "quarantine", appState: appState)
                 }
 
             }

--- a/Sentinel/Utilities/Commands.swift
+++ b/Sentinel/Utilities/Commands.swift
@@ -161,7 +161,7 @@ func CmdRunDrop(cmd: String, type: String, sudo: Bool = false, appState: AppStat
 
 func checkQuarantineRemoved(cmd: String) async -> Bool {
     // Adjust command to check for quarantine attribute, e.g., `xattr`
-    let checkCmd = "xattr -p com.apple.quarantine \(cmd)"
+    let checkCmd = cmd.replacingOccurrences(of: "xattr -rd com.apple.quarantine", with: "xattr")
     let source = """
                     set the_script to "\(checkCmd)"
                     set the_result to do shell script the_script


### PR DESCRIPTION
This fix takes into account the possibility of blanks in an application name and quotes it when calling `xattr`.

It then calls simply `xattr` to verify that its output doesn't contain anymore the `com.apple.quarantine` attribute.