### PR TITLE
Fix `checkQuarantineRemoved`

### DIFF
--- a/Sentinel/Utilities/CmdDrops.swift
+++ b/Sentinel/Utilities/CmdDrops.swift
@@ -123,7 +123,7 @@ func CmdRunDrop(cmd: String, path: String, type: cmdType, sudo: Bool = false, ap
 
 func checkQuarantineRemoved(path: String) async -> Bool {
     let out = runShCommand("xattr -p com.apple.quarantine '\(path)'")
-    return !out.standardOutput.contains("com.apple.quarantine")
+    return out.standardOutput.isEmpty
 }
 
 func checkAppSigned(path: String) async -> Bool {


### PR DESCRIPTION
The command `xattr -p com.apple.quarantine '\(path)’` outputs directly the contents of the quarantine attribute or a null string when it has been removed (and the message “No such xattr: com.apple.quarantine” in `standardError`) .

`checkQuarantineRemoved` should therefore return  just `out.standardOutput.isEmpty`.